### PR TITLE
Increase layout padding between components

### DIFF
--- a/qorkme/app/globals.css
+++ b/qorkme/app/globals.css
@@ -271,7 +271,7 @@ pre {
 .card {
   background: var(--color-surface);
   border-radius: var(--radius-xl);
-  padding: clamp(1.5rem, 1.5vw + 1.25rem, 2.5rem);
+  padding: clamp(1.75rem, 1.6vw + 1.5rem, 3rem);
   border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
   box-shadow: 0 18px 35px -25px var(--color-shadow);
   transition:
@@ -354,7 +354,7 @@ pre {
 }
 
 .container {
-  width: min(1120px, calc(100% - 2.5rem));
+  width: min(1120px, calc(100% - 3rem));
   margin-inline: auto;
 }
 

--- a/qorkme/app/page.tsx
+++ b/qorkme/app/page.tsx
@@ -59,26 +59,26 @@ export default function Home() {
       <div className="flex min-h-screen flex-col bg-background transition-colors duration-300">
         <NavigationHeader />
 
-        <main className="flex flex-1 flex-col pt-28 md:pt-32">
-          <section className="relative px-6 pb-24">
-            <div className="container grid gap-12 lg:grid-cols-[1.05fr_0.95fr]">
-              <div className="space-y-10">
-                <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-4 py-2 text-sm font-semibold text-[color:var(--color-primary)]">
+        <main className="flex flex-1 flex-col space-y-24 px-6 pb-32 pt-28 md:space-y-28 md:pt-32 lg:space-y-32">
+          <section className="relative">
+            <div className="container grid gap-14 lg:grid-cols-[1.05fr_0.95fr] lg:gap-16">
+              <div className="space-y-12">
+                <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-5 py-2.5 text-sm font-semibold text-[color:var(--color-primary)]">
                   <Sparkles size={18} aria-hidden="true" />
                   Premium link studio
                 </span>
-                <div className="space-y-6">
+                <div className="space-y-8">
                   <h1 className="font-display text-4xl sm:text-5xl lg:text-6xl font-semibold leading-tight">
                     Precision short links for teams that move quickly
                   </h1>
-                  <p className="max-w-2xl text-lg text-text-secondary">
+                  <p className="max-w-2xl text-lg leading-relaxed text-text-secondary">
                     QorkMe pairs intentional spacing, friendly forms, and consistent cards with the
                     analytics and controls growing brands expect. Toggle themes, resize the window, and
                     every surface adapts gracefully.
                   </p>
                 </div>
 
-                <div className="flex flex-col gap-3 sm:flex-row">
+                <div className="flex flex-col gap-4 sm:flex-row">
                   <Link href="#shorten" className="inline-flex">
                     <Button size="lg" className="w-full sm:w-auto">
                       Start shortening
@@ -92,7 +92,7 @@ export default function Home() {
                   </Link>
                 </div>
 
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:gap-8">
                   {heroHighlights.map((highlight) => (
                     <MetricCard
                       key={highlight.title}
@@ -117,10 +117,10 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="px-6 pb-24">
-            <div className="container space-y-12">
+          <section>
+            <div className="container space-y-14">
               <Card hoverable={false} className="mx-auto max-w-4xl text-center">
-                <div className="space-y-4">
+                <div className="space-y-5">
                   <h2 className="font-display text-3xl md:text-4xl text-text-primary">
                     Why discerning teams choose QorkMe
                   </h2>
@@ -132,7 +132,7 @@ export default function Home() {
                 </div>
               </Card>
 
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
                 <FeatureCard
                   icon={<Zap size={24} aria-hidden="true" />}
                   title="Lightning fast"
@@ -167,8 +167,8 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="px-6 pb-24">
-            <div className="container grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <section>
+            <div className="container grid grid-cols-1 gap-6 sm:grid-cols-2 md:gap-8 xl:grid-cols-4">
               {stats.map((stat) => (
                 <MetricCard
                   key={stat.label}
@@ -181,10 +181,10 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="px-6 pb-28">
+          <section>
             <div className="container max-w-4xl">
               <Card hoverable={false} className="text-center">
-                <div className="space-y-6">
+                <div className="space-y-8">
                   <h2 className="font-display text-3xl md:text-4xl text-text-primary">
                     Ready to elevate every link?
                   </h2>
@@ -193,15 +193,15 @@ export default function Home() {
                     considered, cohesive, and measurable. Switch the theme, resize the browser—every
                     detail stays balanced.
                   </p>
-                  <div className="flex flex-col justify-center gap-3 sm:flex-row">
+                  <div className="flex flex-col justify-center gap-4 sm:flex-row">
                     <Link href="#shorten" className="inline-flex">
-                      <Button size="lg" className="w-full sm:w-auto">
+                      <Button size="lg" className="w-full px-8 sm:w-auto">
                         Create a short link
                         <ArrowUpRight size={20} aria-hidden="true" />
                       </Button>
                     </Link>
                     <Link href="/docs" className="inline-flex">
-                      <Button variant="outline" size="lg" className="w-full sm:w-auto">
+                      <Button variant="outline" size="lg" className="w-full px-8 sm:w-auto">
                         View documentation
                       </Button>
                     </Link>

--- a/qorkme/app/result/[id]/page.tsx
+++ b/qorkme/app/result/[id]/page.tsx
@@ -72,8 +72,8 @@ export default async function ResultPage({ params }: ResultPageProps) {
       <div className="flex min-h-screen flex-col bg-background transition-colors duration-300">
         <ResultNavigationHeader />
 
-        <main className="flex flex-1 flex-col px-6 pb-24 pt-32 md:pt-36">
-          <div className="container mx-auto max-w-5xl space-y-14">
+        <main className="flex flex-1 flex-col space-y-20 px-6 pb-32 pt-32 md:space-y-24 md:pt-36">
+          <div className="container mx-auto max-w-5xl space-y-16">
             <ShortUrlDisplay
               shortCode={url.short_code}
               longUrl={url.long_url}
@@ -81,7 +81,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
               createdAt={url.created_at}
             />
 
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
               {detailCards.map((stat) => (
                 <MetricCard
                   key={stat.title}
@@ -94,7 +94,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
             </div>
 
             <Card hoverable={false} className="text-center">
-              <CardContent className="space-y-6 py-10">
+              <CardContent className="space-y-8 py-12">
                 <h3 className="font-display text-2xl md:text-3xl text-text-primary">
                   Need deeper analytics?
                 </h3>

--- a/qorkme/components/ShortUrlDisplay.tsx
+++ b/qorkme/components/ShortUrlDisplay.tsx
@@ -57,14 +57,14 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
   };
 
   return (
-    <div className="w-full space-y-6">
+    <div className="w-full space-y-8">
       {/* Success Message */}
       <div
-        className="flex items-start gap-4 rounded-[var(--radius-xl)] border border-[color:var(--color-primary)]/25 bg-[color:var(--color-primary)]/10 px-5 py-4 text-[color:var(--color-primary)] animate-fadeIn"
+        className="flex items-start gap-5 rounded-[var(--radius-xl)] border border-[color:var(--color-primary)]/25 bg-[color:var(--color-primary)]/10 px-6 py-5 text-[color:var(--color-primary)] animate-fadeIn"
         role="status"
         aria-live="polite"
       >
-        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--color-primary)]/20">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:var(--color-primary)]/20">
           <CheckCircle size={22} aria-hidden="true" />
         </div>
         <div className="space-y-1">
@@ -87,8 +87,8 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
           <CardDescription>Share this branded redirect with your audience in seconds.</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="space-y-5">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="space-y-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
               <Input
                 type="text"
                 value={fullShortUrl}
@@ -112,7 +112,7 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
             </div>
 
             {/* Action Buttons */}
-            <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="flex flex-col gap-4 sm:flex-row">
               <Button variant="outline" size="sm" onClick={generateQrCode}>
                 <QrCode size={18} aria-hidden="true" />
                 {showQr ? 'Hide' : 'Show'} QR Code
@@ -134,9 +134,9 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
           hoverable={false}
           className="animate-fadeIn"
         >
-          <CardContent className="text-center py-8 space-y-4">
+          <CardContent className="space-y-6 py-10 text-center">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={qrCodeUrl} alt="QR Code" className="mx-auto mb-4" />
+            <img src={qrCodeUrl} alt="QR Code" className="mx-auto mb-5" />
             <p className="text-text-secondary">Scan this QR code to visit your shortened URL</p>
           </CardContent>
         </Card>
@@ -144,23 +144,23 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
 
       {/* Original URL Info */}
       <Card hoverable={false} className="animate-fadeIn" style={{ animationDelay: '0.2s' }}>
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-3">
           <CardTitle className="text-xl">Link details</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="space-y-4">
-            <div className="flex items-start gap-3">
+          <div className="space-y-5">
+            <div className="flex items-start gap-4">
               <Link2 className="mt-1 text-text-muted" size={18} aria-hidden="true" />
               <div className="flex-1">
                 <p className="mb-1 text-sm font-medium text-text-secondary">Original URL</p>
-                <p className="break-all rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-3 py-2 font-mono text-sm text-text-muted">
+                <p className="break-all rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-4 py-2.5 font-mono text-sm text-text-muted">
                   {longUrl}
                 </p>
               </div>
             </div>
 
             {domain && (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-4">
                 <Globe className="text-text-muted" size={18} aria-hidden="true" />
                 <div>
                   <p className="mb-1 text-sm font-medium text-text-secondary">Domain</p>
@@ -170,7 +170,7 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
             )}
 
             {createdAt && (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-4">
                 <Calendar className="text-text-muted" size={18} aria-hidden="true" />
                 <div>
                   <p className="mb-1 text-sm font-medium text-text-secondary">Created</p>

--- a/qorkme/components/SiteFooter.tsx
+++ b/qorkme/components/SiteFooter.tsx
@@ -7,8 +7,8 @@ interface SiteFooterProps {
 
 export function SiteFooter({ subtitle = 'Thoughtful short links for modern teams', className }: SiteFooterProps) {
   return (
-    <footer className={cn('border-t border-border py-10', className)}>
-      <div className="container flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <footer className={cn('border-t border-border py-12', className)}>
+      <div className="container flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-col gap-1">
           <span className="font-display text-xl font-semibold text-text-primary uppercase tracking-[0.12em]">
             QorkMe

--- a/qorkme/components/UrlShortener.tsx
+++ b/qorkme/components/UrlShortener.tsx
@@ -75,7 +75,7 @@ export function UrlShortener() {
 
   return (
     <>
-      <CardHeader className="space-y-3 text-left">
+      <CardHeader className="space-y-4 text-left">
         <CardTitle className="text-2xl md:text-3xl">Create a short link</CardTitle>
         <CardDescription className="text-base text-text-secondary">
           Paste a destination URL and optionally layer on a custom alias. Every field is spaced for
@@ -83,9 +83,9 @@ export function UrlShortener() {
         </CardDescription>
       </CardHeader>
       <CardContent className="pt-0">
-        <form onSubmit={handleSubmit} className="space-y-8">
+        <form onSubmit={handleSubmit} className="space-y-10">
           {/* Main URL Input */}
-          <div className="space-y-2">
+          <div className="space-y-3">
             <label htmlFor="url" className="block text-sm font-semibold text-text-secondary">
               Destination URL
             </label>
@@ -109,13 +109,13 @@ export function UrlShortener() {
           </div>
 
           {/* Custom Alias Section */}
-          <div className="space-y-4">
+          <div className="space-y-5">
             <button
               type="button"
               onClick={() => setShowCustom(!showCustom)}
               aria-expanded={showCustom}
               aria-controls={aliasSectionId}
-              className="flex w-full items-center justify-between gap-3 rounded-[var(--radius-md)] border border-border bg-[color:var(--color-surface-elevated)]/65 px-4 py-3 text-left transition-colors hover:border-border-strong"
+              className="flex w-full items-center justify-between gap-3 rounded-[var(--radius-md)] border border-border bg-[color:var(--color-surface-elevated)]/65 px-5 py-3.5 text-left transition-colors hover:border-border-strong"
             >
               <span className="flex items-center gap-3 text-sm font-semibold text-text-primary">
                 <Settings2 size={20} aria-hidden="true" />
@@ -133,13 +133,13 @@ export function UrlShortener() {
                 id={aliasSectionId}
                 role="region"
                 aria-label="Custom alias options"
-                className="animate-slideIn space-y-3 rounded-[var(--radius-lg)] border border-border bg-[color:var(--color-surface)] p-5 shadow-soft"
+                className="animate-slideIn space-y-4 rounded-[var(--radius-lg)] border border-border bg-[color:var(--color-surface)] p-6 shadow-soft"
               >
                 <label htmlFor="alias" className="block text-sm font-semibold text-text-secondary">
                   Custom alias
                 </label>
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                  <span className="inline-flex items-center rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-3 py-2 font-mono text-sm text-text-muted">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                  <span className="inline-flex items-center rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-4 py-2.5 font-mono text-sm text-text-muted">
                     qork.me/
                   </span>
                   <Input
@@ -177,7 +177,7 @@ export function UrlShortener() {
           </div>
 
           {/* Submit Button */}
-          <div className="pt-2">
+          <div className="pt-3">
             <Button
               type="submit"
               variant="primary"
@@ -200,7 +200,7 @@ export function UrlShortener() {
           </div>
 
           {/* Info Text */}
-          <p className="pt-2 text-center text-xs text-text-muted">
+          <p className="pt-3 text-center text-xs text-text-muted">
             By shortening a URL, you agree to our Terms of Service and Privacy Policy.
           </p>
         </form>

--- a/qorkme/components/cards/MetricCard.tsx
+++ b/qorkme/components/cards/MetricCard.tsx
@@ -42,13 +42,15 @@ export function MetricCard({
   valueClassName,
 }: MetricCardProps) {
   const alignment =
-    layout === 'vertical' ? 'flex-col items-center text-center gap-4' : 'flex-row items-center gap-4';
+    layout === 'vertical'
+      ? 'flex-col items-center text-center gap-5'
+      : 'flex-row items-center gap-5';
 
   return (
     <Card
       hoverable={false}
       className={cn(
-        'px-6 py-5',
+        'px-8 py-6',
         layout === 'vertical' && 'text-center',
         layout === 'vertical' ? 'h-full' : undefined,
         className


### PR DESCRIPTION
## Summary
- enlarge shared card padding and container width so surfaces have more breathing room
- expand spacing and gaps across the homepage, URL shortener, and result views for clearer separation between components
- widen supporting UI elements like metric cards and the footer to match the refreshed layout rhythm

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cd7c84732c8321bbeaa79854e2ac75