### PR TITLE
Improve mobile spacing and header offset

### DIFF
--- a/qorkme/app/globals.css
+++ b/qorkme/app/globals.css
@@ -110,6 +110,23 @@
   --transition-fast: 120ms ease;
   --transition-base: 220ms ease;
   --transition-slow: 380ms ease;
+
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --nav-offset-mobile: calc(var(--safe-area-top) + 6.75rem);
+  --nav-offset-desktop: calc(var(--safe-area-top) + 8rem);
+}
+
+@media (min-width: 768px) {
+  :root {
+    --nav-offset-mobile: calc(var(--safe-area-top) + 7.25rem);
+    --nav-offset-desktop: calc(var(--safe-area-top) + 8.5rem);
+  }
+}
+
+@media (min-width: 1024px) {
+  :root {
+    --nav-offset-desktop: calc(var(--safe-area-top) + 9rem);
+  }
 }
 
 [data-theme='dark'] {
@@ -205,9 +222,21 @@ body::before {
   inset: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 10% 20%, color-mix(in srgb, var(--color-primary) 12%, transparent) 0%, transparent 55%),
-    radial-gradient(circle at 80% 15%, color-mix(in srgb, var(--color-accent) 10%, transparent) 0%, transparent 50%),
-    radial-gradient(circle at 25% 80%, color-mix(in srgb, var(--color-secondary) 6%, transparent) 0%, transparent 55%);
+    radial-gradient(
+      circle at 10% 20%,
+      color-mix(in srgb, var(--color-primary) 12%, transparent) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 80% 15%,
+      color-mix(in srgb, var(--color-accent) 10%, transparent) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      circle at 25% 80%,
+      color-mix(in srgb, var(--color-secondary) 6%, transparent) 0%,
+      transparent 55%
+    );
   opacity: 0.4;
   z-index: -1;
 }
@@ -271,7 +300,7 @@ pre {
 .card {
   background: var(--color-surface);
   border-radius: var(--radius-xl);
-  padding: clamp(1.5rem, 1.5vw + 1.25rem, 2.5rem);
+  padding: clamp(2rem, 1.8vw + 1.65rem, 3.25rem);
   border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
   box-shadow: 0 18px 35px -25px var(--color-shadow);
   transition:
@@ -337,7 +366,10 @@ pre {
   border-radius: var(--radius-md);
   color: var(--color-text-primary);
   font-family: var(--font-body);
-  transition: border-color var(--transition-base), box-shadow var(--transition-base), background-color var(--transition-base);
+  transition:
+    border-color var(--transition-base),
+    box-shadow var(--transition-base),
+    background-color var(--transition-base);
   min-height: 48px;
   padding-inline: 1rem;
 }
@@ -354,7 +386,7 @@ pre {
 }
 
 .container {
-  width: min(1120px, calc(100% - 2.5rem));
+  width: min(1120px, calc(100% - 3rem));
   margin-inline: auto;
 }
 

--- a/qorkme/app/page.tsx
+++ b/qorkme/app/page.tsx
@@ -5,15 +5,7 @@ import { Card } from '@/components/cards/Card';
 import { MetricCard } from '@/components/cards/MetricCard';
 import { Button } from '@/components/ui/Button';
 import { Toaster } from 'react-hot-toast';
-import {
-  ArrowUpRight,
-  BarChart3,
-  Globe,
-  Link2,
-  Shield,
-  Sparkles,
-  Zap,
-} from 'lucide-react';
+import { ArrowUpRight, BarChart3, Globe, Link2, Shield, Sparkles, Zap } from 'lucide-react';
 import Link from 'next/link';
 import { SiteFooter } from '@/components/SiteFooter';
 
@@ -59,26 +51,26 @@ export default function Home() {
       <div className="flex min-h-screen flex-col bg-background transition-colors duration-300">
         <NavigationHeader />
 
-        <main className="flex flex-1 flex-col pt-28 md:pt-32">
-          <section className="relative px-6 pb-24">
-            <div className="container grid gap-12 lg:grid-cols-[1.05fr_0.95fr]">
-              <div className="space-y-10">
-                <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-4 py-2 text-sm font-semibold text-[color:var(--color-primary)]">
+        <main className="flex flex-1 flex-col space-y-28 px-4 pb-32 pt-[var(--nav-offset-mobile)] sm:px-6 md:space-y-32 md:pt-[var(--nav-offset-desktop)] lg:space-y-36">
+          <section className="relative">
+            <div className="container grid gap-16 px-4 sm:px-6 lg:grid-cols-[1.05fr_0.95fr] lg:gap-20">
+              <div className="space-y-14 sm:space-y-16">
+                <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--color-primary)]/10 px-5 py-2.5 text-sm font-semibold text-[color:var(--color-primary)]">
                   <Sparkles size={18} aria-hidden="true" />
                   Premium link studio
                 </span>
-                <div className="space-y-6">
+                <div className="space-y-10 sm:space-y-12">
                   <h1 className="font-display text-4xl sm:text-5xl lg:text-6xl font-semibold leading-tight">
                     Precision short links for teams that move quickly
                   </h1>
-                  <p className="max-w-2xl text-lg text-text-secondary">
+                  <p className="max-w-2xl text-lg leading-relaxed text-text-secondary">
                     QorkMe pairs intentional spacing, friendly forms, and consistent cards with the
-                    analytics and controls growing brands expect. Toggle themes, resize the window, and
-                    every surface adapts gracefully.
+                    analytics and controls growing brands expect. Toggle themes, resize the window,
+                    and every surface adapts gracefully.
                   </p>
                 </div>
 
-                <div className="flex flex-col gap-3 sm:flex-row">
+                <div className="flex flex-col gap-5 sm:flex-row sm:gap-6">
                   <Link href="#shorten" className="inline-flex">
                     <Button size="lg" className="w-full sm:w-auto">
                       Start shortening
@@ -92,7 +84,7 @@ export default function Home() {
                   </Link>
                 </div>
 
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 sm:gap-10 lg:gap-12">
                   {heroHighlights.map((highlight) => (
                     <MetricCard
                       key={highlight.title}
@@ -117,22 +109,22 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="px-6 pb-24">
-            <div className="container space-y-12">
+          <section>
+            <div className="container space-y-16 px-4 sm:px-6 md:space-y-20">
               <Card hoverable={false} className="mx-auto max-w-4xl text-center">
-                <div className="space-y-4">
+                <div className="space-y-6">
                   <h2 className="font-display text-3xl md:text-4xl text-text-primary">
                     Why discerning teams choose QorkMe
                   </h2>
                   <p className="mx-auto max-w-2xl text-base md:text-lg text-text-secondary">
-                    Shared components, measured spacing, and accessible interactions carry across the
-                    entire experience. Cards, buttons, and inputs are reused everywhere so the interface
-                    feels familiar from the homepage to analytics.
+                    Shared components, measured spacing, and accessible interactions carry across
+                    the entire experience. Cards, buttons, and inputs are reused everywhere so the
+                    interface feels familiar from the homepage to analytics.
                   </p>
                 </div>
               </Card>
 
-              <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-1 gap-10 md:grid-cols-2 md:gap-12 xl:grid-cols-3 xl:gap-14">
                 <FeatureCard
                   icon={<Zap size={24} aria-hidden="true" />}
                   title="Lightning fast"
@@ -167,8 +159,8 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="px-6 pb-24">
-            <div className="container grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <section>
+            <div className="container grid grid-cols-1 gap-8 px-4 sm:grid-cols-2 sm:px-6 md:gap-10 xl:grid-cols-4 xl:gap-12">
               {stats.map((stat) => (
                 <MetricCard
                   key={stat.label}
@@ -181,27 +173,27 @@ export default function Home() {
             </div>
           </section>
 
-          <section className="px-6 pb-28">
-            <div className="container max-w-4xl">
+          <section>
+            <div className="container max-w-4xl px-4 sm:px-6">
               <Card hoverable={false} className="text-center">
-                <div className="space-y-6">
+                <div className="space-y-10">
                   <h2 className="font-display text-3xl md:text-4xl text-text-primary">
                     Ready to elevate every link?
                   </h2>
                   <p className="mx-auto max-w-3xl text-base md:text-lg text-text-secondary">
-                    From campaign launches to enterprise migrations, QorkMe keeps your audience journeys
-                    considered, cohesive, and measurable. Switch the theme, resize the browser—every
-                    detail stays balanced.
+                    From campaign launches to enterprise migrations, QorkMe keeps your audience
+                    journeys considered, cohesive, and measurable. Switch the theme, resize the
+                    browser—every detail stays balanced.
                   </p>
-                  <div className="flex flex-col justify-center gap-3 sm:flex-row">
+                  <div className="flex flex-col justify-center gap-5 sm:flex-row sm:gap-6">
                     <Link href="#shorten" className="inline-flex">
-                      <Button size="lg" className="w-full sm:w-auto">
+                      <Button size="lg" className="w-full px-8 sm:w-auto">
                         Create a short link
                         <ArrowUpRight size={20} aria-hidden="true" />
                       </Button>
                     </Link>
                     <Link href="/docs" className="inline-flex">
-                      <Button variant="outline" size="lg" className="w-full sm:w-auto">
+                      <Button variant="outline" size="lg" className="w-full px-8 sm:w-auto">
                         View documentation
                       </Button>
                     </Link>

--- a/qorkme/app/result/[id]/page.tsx
+++ b/qorkme/app/result/[id]/page.tsx
@@ -72,8 +72,8 @@ export default async function ResultPage({ params }: ResultPageProps) {
       <div className="flex min-h-screen flex-col bg-background transition-colors duration-300">
         <ResultNavigationHeader />
 
-        <main className="flex flex-1 flex-col px-6 pb-24 pt-32 md:pt-36">
-          <div className="container mx-auto max-w-5xl space-y-14">
+        <main className="flex flex-1 flex-col space-y-24 px-4 pb-32 pt-[var(--nav-offset-mobile)] sm:px-6 md:space-y-28 md:pt-[var(--nav-offset-desktop)]">
+          <div className="container mx-auto max-w-5xl space-y-16 px-4 sm:px-6 sm:space-y-20 md:space-y-24">
             <ShortUrlDisplay
               shortCode={url.short_code}
               longUrl={url.long_url}
@@ -81,7 +81,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
               createdAt={url.created_at}
             />
 
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <div className="grid grid-cols-1 gap-10 md:grid-cols-3 md:gap-12">
               {detailCards.map((stat) => (
                 <MetricCard
                   key={stat.title}
@@ -94,7 +94,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
             </div>
 
             <Card hoverable={false} className="text-center">
-              <CardContent className="space-y-6 py-10">
+              <CardContent className="space-y-10 py-14">
                 <h3 className="font-display text-2xl md:text-3xl text-text-primary">
                   Need deeper analytics?
                 </h3>

--- a/qorkme/components/NavigationHeader.tsx
+++ b/qorkme/components/NavigationHeader.tsx
@@ -6,8 +6,8 @@ import { Link2 } from 'lucide-react';
 export function NavigationHeader() {
   return (
     <nav className="fixed inset-x-0 top-0 z-50 backdrop-blur-xl">
-      <div className="container py-5">
-        <div className="flex items-center justify-between rounded-[var(--radius-xl)] border border-border bg-[color:var(--color-surface)]/85 px-5 md:px-6 py-3.5 shadow-soft transition-colors">
+      <div className="container px-4 sm:px-6 pb-5 pt-[calc(var(--safe-area-top)+1.25rem)]">
+        <div className="flex items-center justify-between rounded-[var(--radius-xl)] border border-border bg-[color:var(--color-surface)]/90 px-5 md:px-6 py-3.5 shadow-soft transition-colors">
           <div className="flex items-center gap-3">
             <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/12 text-[color:var(--color-primary)]">
               <Link2 size={22} aria-hidden="true" />

--- a/qorkme/components/ResultNavigationHeader.tsx
+++ b/qorkme/components/ResultNavigationHeader.tsx
@@ -7,8 +7,8 @@ import { Link2, ArrowLeft } from 'lucide-react';
 export function ResultNavigationHeader() {
   return (
     <nav className="fixed inset-x-0 top-0 z-50 backdrop-blur-xl">
-      <div className="container py-5">
-        <div className="flex items-center justify-between rounded-[var(--radius-xl)] border border-border bg-[color:var(--color-surface)]/85 px-5 md:px-6 py-3.5 shadow-soft transition-colors">
+      <div className="container px-4 sm:px-6 pb-5 pt-[calc(var(--safe-area-top)+1.25rem)]">
+        <div className="flex items-center justify-between rounded-[var(--radius-xl)] border border-border bg-[color:var(--color-surface)]/90 px-5 md:px-6 py-3.5 shadow-soft transition-colors">
           <Link href="/" className="flex items-center gap-3 text-[color:var(--color-text-primary)]">
             <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/12 text-[color:var(--color-primary)]">
               <Link2 size={20} aria-hidden="true" />

--- a/qorkme/components/ShortUrlDisplay.tsx
+++ b/qorkme/components/ShortUrlDisplay.tsx
@@ -57,14 +57,14 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
   };
 
   return (
-    <div className="w-full space-y-6">
+    <div className="w-full space-y-10">
       {/* Success Message */}
       <div
-        className="flex items-start gap-4 rounded-[var(--radius-xl)] border border-[color:var(--color-primary)]/25 bg-[color:var(--color-primary)]/10 px-5 py-4 text-[color:var(--color-primary)] animate-fadeIn"
+        className="flex items-start gap-6 rounded-[var(--radius-xl)] border border-[color:var(--color-primary)]/25 bg-[color:var(--color-primary)]/10 px-7 py-6 text-[color:var(--color-primary)] animate-fadeIn"
         role="status"
         aria-live="polite"
       >
-        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-[color:var(--color-primary)]/20">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:var(--color-primary)]/20">
           <CheckCircle size={22} aria-hidden="true" />
         </div>
         <div className="space-y-1">
@@ -84,11 +84,13 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
       >
         <CardHeader>
           <CardTitle>Your short link</CardTitle>
-          <CardDescription>Share this branded redirect with your audience in seconds.</CardDescription>
+          <CardDescription>
+            Share this branded redirect with your audience in seconds.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="space-y-5">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="space-y-7 sm:space-y-8">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
               <Input
                 type="text"
                 value={fullShortUrl}
@@ -96,7 +98,11 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
                 aria-label="Shortened URL"
                 className="flex-1 font-mono text-lg"
               />
-              <Button variant={copied ? 'accent' : 'primary'} onClick={copyToClipboard} className="min-w-[120px] justify-center">
+              <Button
+                variant={copied ? 'accent' : 'primary'}
+                onClick={copyToClipboard}
+                className="min-w-[120px] justify-center"
+              >
                 {copied ? (
                   <>
                     <CheckCircle size={18} aria-hidden="true" />
@@ -112,12 +118,17 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
             </div>
 
             {/* Action Buttons */}
-            <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="flex flex-col gap-5 sm:flex-row sm:gap-6">
               <Button variant="outline" size="sm" onClick={generateQrCode}>
                 <QrCode size={18} aria-hidden="true" />
                 {showQr ? 'Hide' : 'Show'} QR Code
               </Button>
-              <a href={fullShortUrl} target="_blank" rel="noopener noreferrer" className="inline-flex">
+              <a
+                href={fullShortUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex"
+              >
                 <Button variant="outline" size="sm">
                   <ExternalLink size={18} aria-hidden="true" />
                   Visit link
@@ -130,13 +141,10 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
 
       {/* QR Code Display */}
       {showQr && qrCodeUrl && (
-        <Card
-          hoverable={false}
-          className="animate-fadeIn"
-        >
-          <CardContent className="text-center py-8 space-y-4">
+        <Card hoverable={false} className="animate-fadeIn">
+          <CardContent className="space-y-8 py-12 text-center">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={qrCodeUrl} alt="QR Code" className="mx-auto mb-4" />
+            <img src={qrCodeUrl} alt="QR Code" className="mx-auto mb-5" />
             <p className="text-text-secondary">Scan this QR code to visit your shortened URL</p>
           </CardContent>
         </Card>
@@ -144,23 +152,23 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
 
       {/* Original URL Info */}
       <Card hoverable={false} className="animate-fadeIn" style={{ animationDelay: '0.2s' }}>
-        <CardHeader className="space-y-2">
+        <CardHeader className="space-y-3">
           <CardTitle className="text-xl">Link details</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="space-y-4">
-            <div className="flex items-start gap-3">
+          <div className="space-y-6">
+            <div className="flex items-start gap-5">
               <Link2 className="mt-1 text-text-muted" size={18} aria-hidden="true" />
               <div className="flex-1">
                 <p className="mb-1 text-sm font-medium text-text-secondary">Original URL</p>
-                <p className="break-all rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-3 py-2 font-mono text-sm text-text-muted">
+                <p className="break-all rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-4 py-2.5 font-mono text-sm text-text-muted">
                   {longUrl}
                 </p>
               </div>
             </div>
 
             {domain && (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-5">
                 <Globe className="text-text-muted" size={18} aria-hidden="true" />
                 <div>
                   <p className="mb-1 text-sm font-medium text-text-secondary">Domain</p>
@@ -170,7 +178,7 @@ export function ShortUrlDisplay({ shortCode, longUrl, domain, createdAt }: Short
             )}
 
             {createdAt && (
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-5">
                 <Calendar className="text-text-muted" size={18} aria-hidden="true" />
                 <div>
                   <p className="mb-1 text-sm font-medium text-text-secondary">Created</p>

--- a/qorkme/components/SiteFooter.tsx
+++ b/qorkme/components/SiteFooter.tsx
@@ -5,17 +5,22 @@ interface SiteFooterProps {
   className?: string;
 }
 
-export function SiteFooter({ subtitle = 'Thoughtful short links for modern teams', className }: SiteFooterProps) {
+export function SiteFooter({
+  subtitle = 'Thoughtful short links for modern teams',
+  className,
+}: SiteFooterProps) {
   return (
-    <footer className={cn('border-t border-border py-10', className)}>
-      <div className="container flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <footer className={cn('border-t border-border py-16', className)}>
+      <div className="container flex flex-col gap-6 px-4 sm:px-6 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-col gap-1">
           <span className="font-display text-xl font-semibold text-text-primary uppercase tracking-[0.12em]">
             QorkMe
           </span>
           <span className="text-sm text-text-muted">{subtitle}</span>
         </div>
-        <p className="text-sm text-text-muted">Designed in San Francisco • Powered by Supabase &amp; Vercel</p>
+        <p className="text-sm text-text-muted">
+          Designed in San Francisco • Powered by Supabase &amp; Vercel
+        </p>
       </div>
     </footer>
   );

--- a/qorkme/components/UrlShortener.tsx
+++ b/qorkme/components/UrlShortener.tsx
@@ -75,7 +75,7 @@ export function UrlShortener() {
 
   return (
     <>
-      <CardHeader className="space-y-3 text-left">
+      <CardHeader className="space-y-5 text-left">
         <CardTitle className="text-2xl md:text-3xl">Create a short link</CardTitle>
         <CardDescription className="text-base text-text-secondary">
           Paste a destination URL and optionally layer on a custom alias. Every field is spaced for
@@ -83,9 +83,9 @@ export function UrlShortener() {
         </CardDescription>
       </CardHeader>
       <CardContent className="pt-0">
-        <form onSubmit={handleSubmit} className="space-y-8">
+        <form onSubmit={handleSubmit} className="space-y-12">
           {/* Main URL Input */}
-          <div className="space-y-2">
+          <div className="space-y-4">
             <label htmlFor="url" className="block text-sm font-semibold text-text-secondary">
               Destination URL
             </label>
@@ -101,7 +101,11 @@ export function UrlShortener() {
                 aria-describedby={urlHelpId}
                 required
               />
-              <Link2 className="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted" size={20} aria-hidden="true" />
+              <Link2
+                className="absolute right-4 top-1/2 -translate-y-1/2 text-text-muted"
+                size={20}
+                aria-hidden="true"
+              />
             </div>
             <p id={urlHelpId} className="text-xs text-text-muted">
               We support http(s) URLs and trackable query strings.
@@ -109,13 +113,13 @@ export function UrlShortener() {
           </div>
 
           {/* Custom Alias Section */}
-          <div className="space-y-4">
+          <div className="space-y-6">
             <button
               type="button"
               onClick={() => setShowCustom(!showCustom)}
               aria-expanded={showCustom}
               aria-controls={aliasSectionId}
-              className="flex w-full items-center justify-between gap-3 rounded-[var(--radius-md)] border border-border bg-[color:var(--color-surface-elevated)]/65 px-4 py-3 text-left transition-colors hover:border-border-strong"
+              className="flex w-full items-center justify-between gap-3 rounded-[var(--radius-md)] border border-border bg-[color:var(--color-surface-elevated)]/65 px-5 py-3.5 text-left transition-colors hover:border-border-strong"
             >
               <span className="flex items-center gap-3 text-sm font-semibold text-text-primary">
                 <Settings2 size={20} aria-hidden="true" />
@@ -133,13 +137,13 @@ export function UrlShortener() {
                 id={aliasSectionId}
                 role="region"
                 aria-label="Custom alias options"
-                className="animate-slideIn space-y-3 rounded-[var(--radius-lg)] border border-border bg-[color:var(--color-surface)] p-5 shadow-soft"
+                className="animate-slideIn space-y-5 rounded-[var(--radius-lg)] border border-border bg-[color:var(--color-surface)] p-6 shadow-soft"
               >
                 <label htmlFor="alias" className="block text-sm font-semibold text-text-secondary">
                   Custom alias
                 </label>
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                  <span className="inline-flex items-center rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-3 py-2 font-mono text-sm text-text-muted">
+                <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-6">
+                  <span className="inline-flex items-center rounded-[var(--radius-md)] bg-[color:var(--color-surface-elevated)] px-4 py-2.5 font-mono text-sm text-text-muted">
                     qork.me/
                   </span>
                   <Input
@@ -177,7 +181,7 @@ export function UrlShortener() {
           </div>
 
           {/* Submit Button */}
-          <div className="pt-2">
+          <div className="pt-4">
             <Button
               type="submit"
               variant="primary"
@@ -192,7 +196,11 @@ export function UrlShortener() {
                 </>
               ) : (
                 <>
-                  <Zap size={20} className="text-[color:var(--color-text-inverse)]" aria-hidden="true" />
+                  <Zap
+                    size={20}
+                    className="text-[color:var(--color-text-inverse)]"
+                    aria-hidden="true"
+                  />
                   <span>Shorten URL</span>
                 </>
               )}
@@ -200,7 +208,7 @@ export function UrlShortener() {
           </div>
 
           {/* Info Text */}
-          <p className="pt-2 text-center text-xs text-text-muted">
+          <p className="pt-4 text-center text-xs text-text-muted">
             By shortening a URL, you agree to our Terms of Service and Privacy Policy.
           </p>
         </form>

--- a/qorkme/components/cards/MetricCard.tsx
+++ b/qorkme/components/cards/MetricCard.tsx
@@ -42,13 +42,15 @@ export function MetricCard({
   valueClassName,
 }: MetricCardProps) {
   const alignment =
-    layout === 'vertical' ? 'flex-col items-center text-center gap-4' : 'flex-row items-center gap-4';
+    layout === 'vertical'
+      ? 'flex-col items-center text-center gap-5'
+      : 'flex-row items-center gap-5';
 
   return (
     <Card
       hoverable={false}
       className={cn(
-        'px-6 py-5',
+        'px-8 py-6',
         layout === 'vertical' && 'text-center',
         layout === 'vertical' ? 'h-full' : undefined,
         className


### PR DESCRIPTION
## Summary
- add safe-area aware navigation offsets and expand base card padding for consistent spacing under the fixed headers
- increase homepage section gaps and container padding so mobile layouts gain more breathing room
- widen spacing inside the shortener form, result display, and footer to align touch targets across screens

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cd7c84732c8321bbeaa79854e2ac75