### PR TITLE
Increase navigation horizontal padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
--## 2025-09-22 02:15
+## 2025-09-22 03:35
+- Increased the horizontal padding inside both navigation shells so edge-aligned controls sit further from the glassmorphism frame.
+
+## 2025-09-22 03:10
+- Refined the workspace navigation styling to mirror the refreshed application header, calling out the new gradient framing and widened action spacing.
+
+## 2025-09-22 02:15
 - Added `TODO-2025-09-22.md` at repository root capturing Supabase deployment tasks for later completion today.
 
 ## 2025-09-22 02:05

--- a/qorkme/CHANGELOG.md
+++ b/qorkme/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the QorkMe URL Shortener project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.5] - 2025-09-22
+
+### Changed
+
+- Increased the horizontal padding inside both navigation headers so back links, live indicators, and the theme toggle sit further from the glass frame edges.
+
+## [3.0.4] - 2025-09-22
+
+### Changed
+
+- Redesigned both navigation headers with a broader glassmorphism frame, gradient accents, and expanded internal padding for clearer breathing room.
+- Grouped the header action controls within pill-shaped containers to prevent the Live badge and theme toggle from crowding the navbar edges.
+
 ## [3.0.3] - 2025-09-22
 
 ### Added

--- a/qorkme/components/NavigationHeader.tsx
+++ b/qorkme/components/NavigationHeader.tsx
@@ -7,29 +7,37 @@ export function NavigationHeader() {
   return (
     <nav className="fixed inset-x-0 top-0 z-50 backdrop-blur-xl">
       <div className="container py-6">
-        <div className="flex flex-wrap items-center justify-between gap-5 rounded-[calc(var(--radius-xl)+6px)] border border-border/55 bg-[color:var(--color-surface)]/95 px-8 py-4 shadow-soft transition-colors">
-          <div className="flex items-center gap-5">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/16 text-[color:var(--color-primary)] shadow-soft">
-              <Link2 size={22} aria-hidden="true" />
+        <div className="relative overflow-hidden rounded-[calc(var(--radius-xl)+12px)] border border-border/45 bg-[color:var(--color-surface)]/90 shadow-soft transition-colors">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 scale-[1.02] bg-gradient-to-r from-[color:var(--color-primary)]/25 via-transparent to-[color:var(--color-secondary)]/30 opacity-80"
+          />
+          <div className="relative flex flex-wrap items-center justify-between gap-6 px-10 py-5 sm:px-16">
+            <div className="flex items-center gap-4 sm:gap-6">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/16 text-[color:var(--color-primary)] shadow-soft">
+                <Link2 size={22} aria-hidden="true" />
+              </div>
+              <div className="flex flex-col gap-1 leading-tight">
+                <span className="font-ui text-lg font-extrabold uppercase tracking-[0.28em] text-[color:var(--color-secondary)]">
+                  QorkMe
+                </span>
+                <span className="font-body text-sm font-medium text-[color:var(--color-text-muted)]">
+                  Friendly link studio
+                </span>
+              </div>
             </div>
-            <div className="flex flex-col gap-1 leading-tight">
-              <span className="font-ui text-lg font-extrabold uppercase tracking-[0.28em] text-[color:var(--color-secondary)]">
-                QorkMe
-              </span>
-              <span className="font-body text-sm font-medium text-[color:var(--color-text-muted)]">
-                Friendly link studio
-              </span>
+            <div className="flex items-center gap-3 sm:gap-5">
+              <div className="hidden sm:flex items-center gap-2 rounded-full border border-border/55 bg-[color:var(--color-background-accent)]/80 px-5 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.28em] text-[color:var(--color-secondary)] shadow-soft">
+                <span
+                  className="inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--color-primary)]"
+                  aria-hidden="true"
+                />
+                Live session
+              </div>
+              <div className="rounded-full bg-[color:var(--color-background)]/75 px-3 py-1.5 shadow-soft ring-1 ring-border/45">
+                <ClientThemeToggle />
+              </div>
             </div>
-          </div>
-          <div className="flex items-center gap-4">
-            <div className="hidden sm:flex items-center gap-2 rounded-full border border-border/55 bg-[color:var(--color-background-accent)]/75 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--color-secondary)]">
-              <span
-                className="inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--color-primary)]"
-                aria-hidden="true"
-              />
-              Live
-            </div>
-            <ClientThemeToggle />
           </div>
         </div>
       </div>

--- a/qorkme/components/ResultNavigationHeader.tsx
+++ b/qorkme/components/ResultNavigationHeader.tsx
@@ -8,29 +8,40 @@ export function ResultNavigationHeader() {
   return (
     <nav className="fixed inset-x-0 top-0 z-50 backdrop-blur-xl">
       <div className="container py-6">
-        <div className="flex flex-wrap items-center justify-between gap-5 rounded-[calc(var(--radius-xl)+6px)] border border-border/55 bg-[color:var(--color-surface)]/95 px-8 py-4 shadow-soft transition-colors">
-          <Link href="/" className="flex items-center gap-5 text-[color:var(--color-text-primary)]">
-            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/16 text-[color:var(--color-primary)] shadow-soft">
-              <Link2 size={22} aria-hidden="true" />
-            </div>
-            <div className="flex flex-col gap-1 leading-tight">
-              <span className="font-ui text-lg font-extrabold uppercase tracking-[0.28em]">
-                QorkMe
-              </span>
-              <span className="font-body text-sm font-medium text-[color:var(--color-text-muted)]">
-                Share-ready link
-              </span>
-            </div>
-          </Link>
-          <div className="flex items-center gap-4">
+        <div className="relative overflow-hidden rounded-[calc(var(--radius-xl)+12px)] border border-border/45 bg-[color:var(--color-surface)]/90 shadow-soft transition-colors">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 scale-[1.02] bg-gradient-to-r from-[color:var(--color-primary)]/25 via-transparent to-[color:var(--color-secondary)]/30 opacity-80"
+          />
+          <div className="relative flex flex-wrap items-center justify-between gap-6 px-10 py-5 sm:px-16">
             <Link
               href="/"
-              className="inline-flex items-center gap-2 rounded-full border border-border/55 bg-[color:var(--color-background-accent)]/75 px-5 py-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--color-secondary)] transition-colors hover:border-[color:var(--color-primary)]/60 hover:text-[color:var(--color-primary)]"
+              className="flex items-center gap-4 text-[color:var(--color-text-primary)] sm:gap-6"
             >
-              <ArrowLeft size={18} aria-hidden="true" />
-              <span>Start another link</span>
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-[color:var(--color-primary)]/16 text-[color:var(--color-primary)] shadow-soft">
+                <Link2 size={22} aria-hidden="true" />
+              </div>
+              <div className="flex flex-col gap-1 leading-tight">
+                <span className="font-ui text-lg font-extrabold uppercase tracking-[0.28em]">
+                  QorkMe
+                </span>
+                <span className="font-body text-sm font-medium text-[color:var(--color-text-muted)]">
+                  Share-ready link
+                </span>
+              </div>
             </Link>
-            <ClientThemeToggle />
+            <div className="flex items-center gap-3 sm:gap-5">
+              <Link
+                href="/"
+                className="inline-flex items-center gap-2 rounded-full border border-border/55 bg-[color:var(--color-background-accent)]/80 px-6 py-2.5 text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--color-secondary)] shadow-soft transition-colors hover:border-[color:var(--color-primary)]/60 hover:text-[color:var(--color-primary)]"
+              >
+                <ArrowLeft size={18} aria-hidden="true" />
+                <span>Start another link</span>
+              </Link>
+              <div className="rounded-full bg-[color:var(--color-background)]/75 px-3 py-1.5 shadow-soft ring-1 ring-border/45">
+                <ClientThemeToggle />
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- widen the internal padding on both navigation headers so edge-aligned controls sit farther from the glass frame
- document the additional padding treatment in the workspace and application changelog entries

## Testing
- npm run lint
- npm run type-check
- npm test
- npx prettier --check .
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d49925a56083219cf8aaca1e574374