### PR TITLE
Broaden SiteHeader horizontal padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-09-27 05:30
+- Nudged the marketing navbar's internal padding wider so the bordered frame stretches further on desktop and mobile while keeping the glassmorphism shell responsive.
+
+## 2025-09-27 04:45
+- Softened the marketing navbar badge styling to remove the pill treatment and pulled the call-to-action button to keep the header minimal while preserving comfortable spacing.
+
 ## 2025-09-27 03:19
 - Rebuilt the QorkMe navbar with a standard glassmorphism top bar, unified desktop/mobile layouts, and simplified status/action treatments for consistency across pages.
 

--- a/qorkme/CHANGELOG.md
+++ b/qorkme/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the QorkMe URL Shortener project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.8] - 2025-09-27
+
+### Changed
+
+- Widened the SiteHeader's horizontal padding steps so the bordered glass frame breathes more on every breakpoint without breaking responsive alignment.
+
+## [3.0.7] - 2025-09-27
+
+### Changed
+
+- Simplified the navigation status treatment to a text-only callout and removed the marketing header action button to reduce visual weight while keeping spacing comfortable.
+
 ## [3.0.6] - 2025-09-27
 
 ### Changed

--- a/qorkme/components/NavigationHeader.tsx
+++ b/qorkme/components/NavigationHeader.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import { SiteHeader } from '@/components/SiteHeader';
 
 const navItems = [
@@ -15,11 +15,6 @@ export function NavigationHeader() {
       status={{
         label: 'Beta invites open',
         icon: <Sparkles size={16} aria-hidden />,
-      }}
-      action={{
-        label: 'Start shortening',
-        href: '#shorten',
-        icon: <ArrowUpRight size={18} aria-hidden />,
       }}
       brandTagline="Friendly link studio"
     />

--- a/qorkme/components/SiteHeader.tsx
+++ b/qorkme/components/SiteHeader.tsx
@@ -76,7 +76,7 @@ export function SiteHeader({
     <nav className="fixed inset-x-0 top-0 z-50">
       <div className="container py-4">
         <div className="rounded-[24px] border border-border/50 bg-[color:var(--color-surface)]/92 backdrop-blur-lg shadow-[0_18px_50px_-30px_rgba(31,31,29,0.65)]">
-          <div className="flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-between px-5 sm:px-8 lg:px-12">
             <Link
               href="/"
               className="flex items-center gap-3 text-[color:var(--color-text-primary)]"
@@ -125,7 +125,7 @@ export function SiteHeader({
                 )}
 
                 {status && (
-                  <span className="inline-flex items-center gap-2 rounded-full border border-border/55 bg-[color:var(--color-background-accent)]/80 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.26em] text-[color:var(--color-secondary)]">
+                  <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.26em] text-[color:var(--color-secondary)]">
                     {status.icon}
                     {status.label}
                   </span>
@@ -146,7 +146,7 @@ export function SiteHeader({
             <div
               id={menuId}
               className={clsx(
-                'md:hidden px-4 pb-4 transition-[opacity,transform] duration-200 ease-out',
+                'md:hidden px-5 pb-4 transition-[opacity,transform] duration-200 ease-out',
                 isMenuOpen
                   ? 'pointer-events-auto opacity-100'
                   : 'pointer-events-none opacity-0 -translate-y-1'
@@ -168,7 +168,7 @@ export function SiteHeader({
 
                 {status && (
                   <div className="mt-4">
-                    <span className="inline-flex items-center gap-2 rounded-full border border-border/55 bg-[color:var(--color-background-accent)]/85 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.26em] text-[color:var(--color-secondary)]">
+                    <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.26em] text-[color:var(--color-secondary)]">
                       {status.icon}
                       {status.label}
                     </span>


### PR DESCRIPTION
## Summary
- widen the SiteHeader interior padding scale so the bordered glass frame breathes more at each breakpoint
- note the navigation padding adjustment in both workspace and app changelogs

## Testing
- npm run lint
- npm run type-check
- npm test
- npm run format:check
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab18ee1fc8321bd920d8dbeebb0af