### PR TITLE
Optimize bundle size check to reuse build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: npx prettier --check .
 
       - name: Build application
+        id: build
         run: npm run build
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co' }}
@@ -50,8 +51,8 @@ jobs:
           NEXT_PUBLIC_SHORT_DOMAIN: qork.me
 
       - name: Check bundle size
+        if: ${{ always() && steps.build.outcome == 'success' }}
         run: |
-          npm run build
           echo "Build size report:"
           du -sh .next/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2025-09-27 06:40
+- Optimized the CI bundle size check to reuse the existing Next.js build artifacts so the workflow no longer performs a redundant rebuild when reporting `.next/` size.
+
 ## 2025-09-27 05:30
 - Nudged the marketing navbar's internal padding wider so the bordered frame stretches further on desktop and mobile while keeping the glassmorphism shell responsive.
 

--- a/qorkme/CHANGELOG.md
+++ b/qorkme/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the QorkMe URL Shortener project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.9] - 2025-09-27
+
+### Changed
+
+- Sped up CI by letting the bundle size audit reuse the `.next/` output from the build step instead of rebuilding the app during reporting.
+
 ## [3.0.8] - 2025-09-27
 
 ### Changed


### PR DESCRIPTION
## Summary
- reuse the existing Next.js build output for the CI bundle size check and only run it when the build succeeds
- document the workflow optimization in both changelog files

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e40f5167588321a5a063ce2b72c5c4