### PR TITLE
Remove navigation header tagline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2025-09-27 08:40
+- Removed the navigation tagline entirely so the QorkMe wordmark stands alone in every header context without fallback copy.
+
+## 2025-09-27 08:10
+- Removed the marketing navigation badge and default tagline so the homepage header now focuses on the core links while keeping branded taglines opt-in for other contexts.
+
+## 2025-09-27 07:15
+- Replaced the homepage hero's "Friendly link studio" badge with share-ready messaging to keep the header section aligned with the new minimal navigation shell.
+
 ## 2025-09-27 06:40
 - Optimized the CI bundle size check to reuse the existing Next.js build artifacts so the workflow no longer performs a redundant rebuild when reporting `.next/` size.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ QorkMe features a modern card-based design system with:
 - **Card Architecture**: Elevated components with soft shadows and interactions
 - **Responsive Design**: Mobile-first approach optimized for all devices
 - **Accessibility**: WCAG 2.1 AA compliant with comprehensive keyboard navigation
+- **Hero Share-ready Callout**: Homepage hero badge now reinforces the share-ready positioning without reviving the retired taglines
+- **Tagline-free Masthead**: Navigation header now displays only the QorkMe wordmark so the brand bar stays clean across marketing and app views
 
 See [`qorkme/docs/DESIGN_SYSTEM.md`](qorkme/docs/DESIGN_SYSTEM.md) for complete design specifications.
 

--- a/qorkme/CHANGELOG.md
+++ b/qorkme/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the QorkMe URL Shortener project will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.12] - 2025-09-27
+
+### Changed
+
+- Removed the navigation tagline output so the SiteHeader now renders only the QorkMe wordmark across marketing and result views.
+
+## [3.0.11] - 2025-09-27
+
+### Changed
+
+- Reworded the homepage hero badge to spotlight share-ready copy so the marketing header area no longer surfaces the retired "Friendly link studio" tagline.
+
+## [3.0.10] - 2025-09-27
+
+### Changed
+
+- Hid the marketing navigation badge and default tagline so the homepage header stays minimal while still letting result pages opt into contextual branding copy.
+
 ## [3.0.9] - 2025-09-27
 
 ### Changed

--- a/qorkme/README.md
+++ b/qorkme/README.md
@@ -23,6 +23,9 @@ A sophisticated, scalable URL shortener built with Next.js 15, TypeScript, and S
 - **ZT Bros Oskon Typography**: Bold serif fonts with uppercase styling and enhanced spacing
 - **Premium Visual Effects**: Scale transforms, gradient overlays, and sophisticated micro-animations
 - **Integrated Notification System**: Glassmorphic toasts matching the overall aesthetic
+- **Minimal Navigation Header**: Marketing view drops the beta badge by default while keeping optional taglines for result-specific branding
+- **Share-ready Hero Callout**: Homepage hero badge now spotlights the share-ready link studio message to complement the streamlined header
+- **Tagline-free Branding**: Navigation header now presents the QorkMe wordmark on its own across marketing and result contexts for a cleaner masthead
 
 ### Technical Excellence
 

--- a/qorkme/app/page.tsx
+++ b/qorkme/app/page.tsx
@@ -61,7 +61,7 @@ export default function Home() {
                 <div className="flex flex-col gap-12">
                   <span className="inline-flex w-fit items-center gap-2 rounded-full border border-border/60 bg-[color:var(--color-background-accent)]/65 px-5 py-2.5 text-sm font-semibold uppercase tracking-[0.18em] text-[color:var(--color-secondary)]">
                     <Sparkles size={18} aria-hidden="true" />
-                    Friendly link studio
+                    Share-ready link studio
                   </span>
                   <div className="flex flex-col gap-6">
                     <h1 className="font-display text-[clamp(2.75rem,5vw+1.25rem,4.5rem)] font-semibold leading-[1.08] text-text-primary">

--- a/qorkme/components/NavigationHeader.tsx
+++ b/qorkme/components/NavigationHeader.tsx
@@ -1,4 +1,3 @@
-import { Sparkles } from 'lucide-react';
 import { SiteHeader } from '@/components/SiteHeader';
 
 const navItems = [
@@ -9,14 +8,5 @@ const navItems = [
 ];
 
 export function NavigationHeader() {
-  return (
-    <SiteHeader
-      navItems={navItems}
-      status={{
-        label: 'Beta invites open',
-        icon: <Sparkles size={16} aria-hidden />,
-      }}
-      brandTagline="Friendly link studio"
-    />
-  );
+  return <SiteHeader navItems={navItems} />;
 }

--- a/qorkme/components/ResultNavigationHeader.tsx
+++ b/qorkme/components/ResultNavigationHeader.tsx
@@ -22,7 +22,6 @@ export function ResultNavigationHeader() {
         icon: <ArrowLeft size={18} aria-hidden />,
         variant: 'outline',
       }}
-      brandTagline="Share-ready link"
     />
   );
 }

--- a/qorkme/components/SiteHeader.tsx
+++ b/qorkme/components/SiteHeader.tsx
@@ -29,7 +29,6 @@ export interface SiteHeaderProps {
   navItems?: NavItem[];
   status?: HeaderStatus;
   action?: HeaderAction;
-  brandTagline?: string;
 }
 
 const actionStyles: Record<HeaderActionVariant, string> = {
@@ -39,12 +38,7 @@ const actionStyles: Record<HeaderActionVariant, string> = {
     'border border-[color:var(--color-border-strong)] text-[color:var(--color-text-secondary)] bg-transparent hover:text-[color:var(--color-primary)] hover:border-[color:var(--color-primary)] hover:bg-[color:var(--color-primary)]/10',
 };
 
-export function SiteHeader({
-  navItems = [],
-  status,
-  action,
-  brandTagline = 'Friendly link studio',
-}: SiteHeaderProps) {
+export function SiteHeader({ navItems = [], status, action }: SiteHeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuId = useId();
   const hasNavigation = navItems.length > 0;
@@ -87,9 +81,6 @@ export function SiteHeader({
               <span className="flex flex-col leading-tight">
                 <span className="font-ui text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-[color:var(--color-secondary)]">
                   QorkMe
-                </span>
-                <span className="font-body text-sm text-[color:var(--color-text-secondary)]">
-                  {brandTagline}
                 </span>
               </span>
             </Link>


### PR DESCRIPTION
## Summary
- remove the SiteHeader brand tagline prop so the navigation masthead only renders the QorkMe wordmark across marketing and result views
- update both changelog files and READMEs to document the tagline removal for the latest UI tightening

## Testing
- npm run lint
- npm run type-check
- npm test
- npm run format:check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e413c5587c8321afe2bb051d12d667